### PR TITLE
fix: w3c vc document qr code uri

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -784,9 +784,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -850,9 +850,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -914,13 +914,25 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.1.tgz",
-      "integrity": "sha512-0J+zgWxHN+xXONWIyPWKFMgVuJoZuGiIFu8yxk7RJjxkzpGmyja5wRFqZIVtjDVOQpV+Rw0iOAjYPE2eQyjr0w==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.5.tgz",
+      "integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
       "dev": true,
       "dependencies": {
-        "@eslint/core": "^0.14.0",
+        "@eslint/core": "^0.15.2",
         "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
+      "integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2908,9 +2920,9 @@
       "integrity": "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -4062,9 +4074,9 @@
       }
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -4121,9 +4133,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -5219,8 +5231,7 @@
     "node_modules/isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -5915,18 +5926,47 @@
       "dev": true
     },
     "node_modules/pbkdf2": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
-      "integrity": "sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.3.tgz",
+      "integrity": "sha512-wfRLBZ0feWRhCIkoMB6ete7czJcnNnqRpcoWQBLqatqXXmelSRqfdDK4F3u9T2s2cXas/hQJcryI/4lAL+XTlA==",
       "dependencies": {
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4",
-        "ripemd160": "^2.0.1",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
+        "create-hash": "~1.1.3",
+        "create-hmac": "^1.1.7",
+        "ripemd160": "=2.0.1",
+        "safe-buffer": "^5.2.1",
+        "sha.js": "^2.4.11",
+        "to-buffer": "^1.2.0"
       },
       "engines": {
         "node": ">=0.12"
+      }
+    },
+    "node_modules/pbkdf2/node_modules/create-hash": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+      "integrity": "sha512-snRpch/kwQhcdlnZKYanNF1m0RDlrCdSKQaH87w1FCFPVPNCQ/Il9QJKAX2jVBZddRdaHBMC+zXa9Gw9tmkNUA==",
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "node_modules/pbkdf2/node_modules/hash-base": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
+      "integrity": "sha512-0TROgQ1/SxE6KmxWSvXHvRj90/Xo1JvZShofnYF+f6ZsGtR4eES7WfrQzPalmyagfKZCXpVnitiRebZulWsbiw==",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      }
+    },
+    "node_modules/pbkdf2/node_modules/ripemd160": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
+      "integrity": "sha512-J7f4wutN8mdbV08MJnXibYpCOPHR+yzy+iQ/AsjMv2j8cLavQ8VGagDFUwwTAdF8FmRKVeNpbTTEwNHCW1g94w==",
+      "dependencies": {
+        "hash-base": "^2.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "node_modules/picocolors": {
@@ -7329,6 +7369,19 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/to-buffer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.1.tgz",
+      "integrity": "sha512-tB82LpAIWjhLYbqjx3X4zEeHN6M8CiuOEy2JY8SEQVdYRe3CCHOFaqrBW1doLDrfpWhplcW7BL+bO3/6S3pcDQ==",
+      "dependencies": {
+        "isarray": "^2.0.5",
+        "safe-buffer": "^5.2.1",
+        "typed-array-buffer": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -7385,7 +7438,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
       "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
-      "dev": true,
       "dependencies": {
         "call-bound": "^1.0.3",
         "es-errors": "^1.3.0",

--- a/src/data/DocumentsData.ts
+++ b/src/data/DocumentsData.ts
@@ -92,28 +92,28 @@ export const getDocuments = async (): Promise<Document[]> => {
         {
           label: 'Default',
           url: {
-            'W3C VC': docs.coo_default.qrCode.uri,
+            'W3C VC': decodeURIComponent(docs.coo_default.qrCode.uri),
             'OA (Legacy)': decodeOAString(docs.coo_default_oa.data.links.self.href),
           },
         },
         {
           label: 'Redacted',
           url: {
-            'W3C VC': docs.coo_redacted.qrCode.uri,
+            'W3C VC': decodeURIComponent(docs.coo_redacted.qrCode.uri),
             'OA (Legacy)': decodeOAString(docs.coo_redacted_oa.data.links.self.href),
           },
         },
         {
           label: 'Revoked',
           url: {
-            'W3C VC': docs.coo_revoked.qrCode.uri,
+            'W3C VC': decodeURIComponent(docs.coo_revoked.qrCode.uri),
             'OA (Legacy)': decodeOAString(docs.coo_revoked_oa.data.links.self.href),
           },
         },
         {
           label: 'Expired',
           url: {
-            'W3C VC': docs.coo_expired.qrCode.uri,
+            'W3C VC': decodeURIComponent(docs.coo_expired.qrCode.uri),
             'OA (Legacy)': decodeOAString(docs.coo_expired_oa.data.links.self.href),
           },
         },
@@ -133,14 +133,14 @@ export const getDocuments = async (): Promise<Document[]> => {
         {
           label: 'Operative',
           url: {
-            'W3C VC': docs.epn_operative.qrCode.uri,
+            'W3C VC': decodeURIComponent(docs.epn_operative.qrCode.uri),
             'OA (Legacy)': decodeOAString(docs.epn_operative_oa.data.links.self.href),
           },
         },
         {
           label: 'Inoperative',
           url: {
-            'W3C VC': docs.epn_inoperative.qrCode.uri,
+            'W3C VC': decodeURIComponent(docs.epn_inoperative.qrCode.uri),
             'OA (Legacy)': decodeOAString(docs.epn_inoperative_oa.data.links.self.href),
           },
         },
@@ -159,14 +159,14 @@ export const getDocuments = async (): Promise<Document[]> => {
         {
           label: 'Operative',
           url: {
-            'W3C VC': docs.bol_operative.qrCode.uri,
+            'W3C VC': decodeURIComponent(docs.bol_operative.qrCode.uri),
             'OA (Legacy)': decodeOAString(docs.bol_operative_oa.data.links.self.href),
           },
         },
         {
           label: 'Inoperative',
           url: {
-            'W3C VC': docs.bol_inoperative.qrCode.uri,
+            'W3C VC': decodeURIComponent(docs.bol_inoperative.qrCode.uri),
             'OA (Legacy)': decodeOAString(docs.bol_inoperative_oa.data.links.self.href),
           },
         },
@@ -186,28 +186,28 @@ export const getDocuments = async (): Promise<Document[]> => {
         {
           label: 'Default',
           url: {
-            'W3C VC': docs.inv_default.qrCode.uri,
+            'W3C VC': decodeURIComponent(docs.inv_default.qrCode.uri),
             'OA (Legacy)': decodeOAString(docs.inv_default_oa.data.links.self.href),
           },
         },
         {
           label: 'Redacted',
           url: {
-            'W3C VC': docs.inv_redacted.qrCode.uri,
+            'W3C VC': decodeURIComponent(docs.inv_redacted.qrCode.uri),
             'OA (Legacy)': decodeOAString(docs.inv_redacted_oa.data.links.self.href),
           },
         },
         {
           label: 'Revoked',
           url: {
-            'W3C VC': docs.inv_revoked.qrCode.uri,
+            'W3C VC': decodeURIComponent(docs.inv_revoked.qrCode.uri),
             'OA (Legacy)': decodeOAString(docs.inv_revoked_oa.data.links.self.href),
           },
         },
         {
           label: 'Expired',
           url: {
-            'W3C VC': docs.inv_expired.qrCode.uri,
+            'W3C VC': decodeURIComponent(docs.inv_expired.qrCode.uri),
             'OA (Legacy)': decodeOAString(docs.inv_expired_oa.data.links.self.href),
           },
         },
@@ -226,14 +226,14 @@ export const getDocuments = async (): Promise<Document[]> => {
         {
           label: 'Operative',
           url: {
-            'W3C VC': docs.whr_operative.qrCode.uri,
+            'W3C VC': decodeURIComponent(docs.whr_operative.qrCode.uri),
             'OA (Legacy)': decodeOAString(docs.whr_operative_oa.data.links.self.href),
           },
         },
         {
           label: 'Inoperative',
           url: {
-            'W3C VC': docs.whr_inoperative.qrCode.uri,
+            'W3C VC': decodeURIComponent(docs.whr_inoperative.qrCode.uri),
             'OA (Legacy)': decodeOAString(docs.whr_inoperative_oa.data.links.self.href),
           },
         },


### PR DESCRIPTION
## Summary
W3C document's uri is not decoded thus having a redirection issue.

## Changes
* updated the code to decode the uri

## Issues
redirection not working

## Releases
Channels: latest
ETA: Any target release date


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of W3C Verifiable Credential QR code links by using decoded URLs, ensuring more reliable scanning and opening.
  * Applies across key document types and statuses, including Certificates of Origin, Electronic Promissory Notes, Electronic Bills of Lading, Invoices, and Warehouse Receipts (e.g., default/redacted/revoked/expired, operative/inoperative).
  * Legacy OA links remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->