### PR TITLE
fix: rename ePN

### DIFF
--- a/public/static/electronic-promissory-note-inoperative.json
+++ b/public/static/electronic-promissory-note-inoperative.json
@@ -39,22 +39,22 @@
   "type": ["VerifiableCredential"],
   "qrCode": {
     "type": "TrustVCQRCode",
-    "uri": "https%3A%2F%2Factions.tradetrust.io%3Fq%3D%7B%22type%22%3A%22DOCUMENT%22%2C%22payload%22%3A%7B%22uri%22%3A%22https%3A%2F%2Fgallery.tradetrust.io%2Fstatic%2Felectronic-promissory-note-inoperative.json%22%2C%22redirect%22%3A%22https%3A%2F%2Fref.tradetrust.io%2F%22%2C%22chainId%22%3A%22101010%22%7D%7D"
+    "uri": "https%3A%2F%2Factions.tradetrust.io%3Fq%3D%7B%22type%22%3A%22DOCUMENT%22%2C%22payload%22%3A%7B%22uri%22%3A%22https%3A%2F%2Fgallery.tradetrust.io%2Fstatic%2Felectronic-promissory-note-operative.json%22%2C%22redirect%22%3A%22https%3A%2F%2Fref.tradetrust.io%2F%22%2C%22chainId%22%3A%22101010%22%7D%7D"
   },
   "credentialStatus": {
     "type": "TransferableRecords",
     "tokenNetwork": { "chain": "FREE", "chainId": 101010 },
     "tokenRegistry": "0x7202363bBDb126036F7C3243Ebac310d9d145040",
-    "tokenId": "8cc73c2e1cf965aa4109fd8a63227adccc1e3797698a68a239a0bccd57c415a6"
+    "tokenId": "7c8f8316738125ee522c24b4a5dfe4e93d5e9281816c01442cb48aa682bb3c1d"
   },
   "issuer": "did:web:trustvc.github.io:did:1",
   "issuanceDate": "2025-06-19T02:41:46.742Z",
-  "id": "urn:bnid:_:01982cb0-65da-7aa3-b79a-adc862bc2f3c",
+  "id": "urn:bnid:_:01982cb6-ed95-711e-911c-5f495c3329eb",
   "proof": {
     "type": "BbsBlsSignature2020",
-    "created": "2025-07-21T11:13:34Z",
+    "created": "2025-07-21T11:20:42Z",
     "proofPurpose": "assertionMethod",
-    "proofValue": "hn4yKM0VLJU4zlTr50H0ZbEKQC9ptT2aPCGRGWruep8DVAhavFOQERWSyYTYGusoVRW9dvL6q86SfRhfGk7pOUUb4afr7i4iINjRFfggwp48RU1iTmElYcOehaIWzDha2d00FG19aIvEa/pUzEQH+w==",
+    "proofValue": "pk3NROLGyXBed/K2Ihiyhu+OZkBvJ06wuROrQ7mdKJ0mDAAUHTW16gg7IBTbXUSaFJqE2ycnPrtf5ZvITOyyqq2CEw8AFhKo/MHBJQl2prFzdQKekr8jKed2OjaCN7CPdOdh2DbjRJpgenHnvU62Tw==",
     "verificationMethod": "did:web:trustvc.github.io:did:1#keys-1"
   }
 }

--- a/public/static/electronic-promissory-note-operative.json
+++ b/public/static/electronic-promissory-note-operative.json
@@ -39,22 +39,22 @@
   "type": ["VerifiableCredential"],
   "qrCode": {
     "type": "TrustVCQRCode",
-    "uri": "https%3A%2F%2Factions.tradetrust.io%3Fq%3D%7B%22type%22%3A%22DOCUMENT%22%2C%22payload%22%3A%7B%22uri%22%3A%22https%3A%2F%2Fgallery.tradetrust.io%2Fstatic%2Felectronic-promissory-note-operative.json%22%2C%22redirect%22%3A%22https%3A%2F%2Fref.tradetrust.io%2F%22%2C%22chainId%22%3A%22101010%22%7D%7D"
+    "uri": "https%3A%2F%2Factions.tradetrust.io%3Fq%3D%7B%22type%22%3A%22DOCUMENT%22%2C%22payload%22%3A%7B%22uri%22%3A%22https%3A%2F%2Fgallery.tradetrust.io%2Fstatic%2Felectronic-promissory-note-inoperative.json%22%2C%22redirect%22%3A%22https%3A%2F%2Fref.tradetrust.io%2F%22%2C%22chainId%22%3A%22101010%22%7D%7D"
   },
   "credentialStatus": {
     "type": "TransferableRecords",
     "tokenNetwork": { "chain": "FREE", "chainId": 101010 },
     "tokenRegistry": "0x7202363bBDb126036F7C3243Ebac310d9d145040",
-    "tokenId": "7c8f8316738125ee522c24b4a5dfe4e93d5e9281816c01442cb48aa682bb3c1d"
+    "tokenId": "8cc73c2e1cf965aa4109fd8a63227adccc1e3797698a68a239a0bccd57c415a6"
   },
   "issuer": "did:web:trustvc.github.io:did:1",
   "issuanceDate": "2025-06-19T02:41:46.742Z",
-  "id": "urn:bnid:_:01982cb6-ed95-711e-911c-5f495c3329eb",
+  "id": "urn:bnid:_:01982cb0-65da-7aa3-b79a-adc862bc2f3c",
   "proof": {
     "type": "BbsBlsSignature2020",
-    "created": "2025-07-21T11:20:42Z",
+    "created": "2025-07-21T11:13:34Z",
     "proofPurpose": "assertionMethod",
-    "proofValue": "pk3NROLGyXBed/K2Ihiyhu+OZkBvJ06wuROrQ7mdKJ0mDAAUHTW16gg7IBTbXUSaFJqE2ycnPrtf5ZvITOyyqq2CEw8AFhKo/MHBJQl2prFzdQKekr8jKed2OjaCN7CPdOdh2DbjRJpgenHnvU62Tw==",
+    "proofValue": "hn4yKM0VLJU4zlTr50H0ZbEKQC9ptT2aPCGRGWruep8DVAhavFOQERWSyYTYGusoVRW9dvL6q86SfRhfGk7pOUUb4afr7i4iINjRFfggwp48RU1iTmElYcOehaIWzDha2d00FG19aIvEa/pUzEQH+w==",
     "verificationMethod": "did:web:trustvc.github.io:did:1#keys-1"
   }
 }


### PR DESCRIPTION
## Summary
document naming wrongly, so did a swap

## Changes
* update document name, as it was name wrongly

## Issues
document naming wrong:
operative as inoperative
inoperative as operative

## Releases
Channels: latest
ETA: Any target release date


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected QR codes in electronic promissory note samples so each version (operative and inoperative) links to its corresponding document, ensuring scans resolve correctly.

- Chores
  - Refreshed credential metadata (identifiers, status tokens) and regenerated cryptographic proofs and timestamps to align with the updated artifacts. No changes to issuers, issuance dates, or verification method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->