### PR TITLE
fix: update link to point to ref

### DIFF
--- a/src/pages/Gallery/sections/NavBar.tsx
+++ b/src/pages/Gallery/sections/NavBar.tsx
@@ -5,8 +5,8 @@ import { MenuIcon } from 'lucide-react';
 
 const navItems = [
   { label: 'TradeTrust Website', href: 'https://www.tradetrust.io/' },
-  { label: 'Verifier', href: 'https://v5-token-registry.tradetrust.io/' },
-  { label: 'Creator', href: 'https://v5-token-registry.tradetrust.io/creator' },
+  { label: 'Verifier', href: 'https://ref.tradetrust.io/' },
+  { label: 'Creator', href: 'https://ref.tradetrust.io/creator' },
 ];
 
 export const NavBar = (): JSX.Element => {


### PR DESCRIPTION
## Summary
update links to point to ref.tradetrust.io

## Changes
* update links in nav bar

## Issues
links were pointing to old URL and they were broken

## Releases
Channels: latest
ETA: Any target release date


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated navigation links for Verifier and Creator to use the new ref.tradetrust.io domain.
  * Change applies across desktop and mobile navigation menus for consistent behavior.
  * Ensures users are directed to the latest Verifier and Creator experiences.
  * No changes to layout, interactions, or other navigation items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->