### PR TITLE
fix: add cors header to allow access from ref.tradetrust.io

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,5 +5,6 @@
 [[headers]]
   for = "/*"
   [headers.values]
+    Access-Control-Allow-Origin = "https://ref.tradetrust.io"
     X-Frame-Options = "DENY"
     Content-Security-Policy = "frame-ancestors 'none';"

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,4 +5,5 @@
 [[headers]]
   for = "/*"
   [headers.values]
-    Access-Control-Allow-Origin = "*"
+    X-Frame-Options = "DENY"
+    Content-Security-Policy = "frame-ancestors 'none';"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chore**
  * Updated CORS headers to allow cross-origin requests from https://ref.tradetrust.io.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->